### PR TITLE
正常、異常終了処理の追加

### DIFF
--- a/microshell/src/main.rs
+++ b/microshell/src/main.rs
@@ -1,18 +1,19 @@
 use nix::sys::wait::*;
+use nix::sys::signal::*;
 use nix::unistd::{execvp, fork, ForkResult};
 use std::ffi::CString;
 use std::io::{stdin, stdout, Write};
 
 fn main() {
-    loop {
-        let line = read_line();
+    ignore_signals();
+    while let Some(line) = read_line() {
         if !&line.is_empty() {
             exec_cmd(&line);
         }
     }
 }
 
-fn read_line() -> String {
+fn read_line() -> Option<String> {
     print!("$ ");
     stdout().flush().unwrap();
 
@@ -20,15 +21,15 @@ fn read_line() -> String {
     match stdin().read_line(&mut result) {
         Ok(size) => {
             if size == 0 {
-                return "".to_string();
+                None
             } else {
                 let result = result.trim_end();
-                return result.to_string();
+                Some(result.to_string())
             }
         }
         Err(e) => {
             eprintln!("{}", e);
-            return "".to_string();
+            None
         }
     }
 }
@@ -39,10 +40,13 @@ fn exec_cmd(_line: &str) {
             waitpid(child, None).unwrap();
         }
         Ok(ForkResult::Child) => {
+            restore_signals();
+
             let lines = _line.split(' ')
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>();
             let mut cmd = Vec::new();
+
             for argument in lines {
                 cmd.push(CString::new(argument.to_string()).unwrap());
             }
@@ -51,5 +55,21 @@ fn exec_cmd(_line: &str) {
         Err(e) => {
             eprintln!("fork error: {}", e);
         }
+    }
+}
+
+fn ignore_signals() {
+    let sa = SigAction::new(SigHandler::SigIgn, SaFlags::empty(), SigSet::empty());
+    unsafe {
+        sigaction(Signal::SIGINT, &sa).unwrap();
+        sigaction(Signal::SIGQUIT, &sa).unwrap();
+    }
+}
+
+fn restore_signals() {
+    let sa = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
+    unsafe {
+        sigaction(Signal::SIGINT, &sa).unwrap();
+        sigaction(Signal::SIGQUIT, &sa).unwrap();
     }
 }


### PR DESCRIPTION
#13 

- exitで終了処理はしないことにし「Ctrl + d」でのみ正常終了するように修正
- 「Ctrl + c」でshellが終了しないように修正
- 「Ctrl + /」でshellが終了しないように修正